### PR TITLE
fix: failed to resolve entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Light weight package for serializing different crypto addresses",
   "source": "lib/index.js",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "microbundle",


### PR DESCRIPTION
# Issue
There is an error when using vite to build app importing crypto-addr-serialize. See below:
```
[plugin vite:dep-pre-bundle] Failed to resolve entry for package "crypto-addr-codec". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "crypto-addr-codec". The package may have incorrect main/module/exports specified in its package.json.
```

# Why
The file `index.module.js` does not exist in `dist` directory of the package

# How to fix
To use `lib/index.js` instead of `dist/index.module.js` in "module" field of package.json

# P.S.
As a team member of [.bit](https://github.com/dotbitHQ), we have been consistently helping to improve web3 dev community. To make pull requests for projects maintained by other teams is a good way we believe which would benefit all of us in the long run. :)